### PR TITLE
Prevent undefined method errors when include is provided

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -340,7 +340,9 @@ module FastJsonapi
         return if includes.blank?
 
         parse_includes_list(includes).each_key do |include_item|
-          relationship_to_include = relationships_to_serialize[include_item]
+          relationships = relationships_to_serialize || {}
+          relationship_to_include = relationships[include_item]
+
           raise(JSONAPI::Serializer::UnsupportedIncludeError.new(include_item, name)) unless relationship_to_include
 
           relationship_to_include.static_serializer # called for a side-effect to check for a known serializer class.

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -21,5 +21,16 @@ RSpec.describe JSONAPI::Serializer do
           JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
         )
     end
+
+    context 'when include is provided for a resource that does not have relationships' do
+      let(:user) { User.fake }
+
+      it do
+        expect { UserSerializer.new(user, include: ['bad_include']) }
+          .to raise_error(
+            JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
What?
- Default to an empty hash when fetching relationships for a serializer class that does not have any relationships defined.

Why?
Previously, if `include` is passed in as argument for a serializer that does not have relationships defined, then a: `undefined method [] for nil:NilClass` is raised rather than the expected `JSONAPI::Serializer::UnsupportedIncludeError`. This was because `Serializer#relationships_to_serialize` was returning `nil`.

Refs
- https://github.com/jsonapi-serializer/jsonapi-serializer/issues/210

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a
  relevant issue. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added here. -->

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
